### PR TITLE
ENT-4566: import_file.sh expects filters in superhub/import/filters.

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -121,6 +121,9 @@ bundle agent federation_manage_files
       "$(cfengine_enterprise_federation:config.federation_dir)/superhub/import/."
         create => "true",
         perms => default:mog( "600", "root", "root" );
+      "$(cfengine_enterprise_federation:config.federation_dir)/superhub/import/filters/."
+        create => "true",
+        perms => default:mog( "600", "root", "root" );
     am_feeder::
       "$(cfengine_enterprise_federation:config.federation_dir)/fedhub/."
         create => "true",
@@ -172,7 +175,7 @@ bundle agent federation_manage_files
         copy_from => default:local_dcp( "$(this.promise_dirname)/../../../templates/federated_reporting/import_file.sh" ),
         perms => default:mog( "700", "root", "root" );
 
-      "$(cfengine_enterprise_federation:config.bin_dir)/filter.sed"
+      "$(cfengine_enterprise_federation:config.federation_dir)/superhub/import/filters/filter.sed"
         create => "true",
         template_method => "mustache",
         edit_template => "$(this.promise_dirname)/../../../templates/federated_reporting/filter.sed.mustache",


### PR DESCRIPTION
with this I can test the entire process and everything works, both with parallel installed and without. :+1: